### PR TITLE
Fix complex mask backspace issue

### DIFF
--- a/AKNumericFormatter/AKNumericFormatter/AKNumericFormatter.m
+++ b/AKNumericFormatter/AKNumericFormatter/AKNumericFormatter.m
@@ -71,31 +71,21 @@
   if( onlyDigitsString.length == 0 ) {
     return @"";
   }
-  NSMutableString* formattedString = [NSMutableString string];
-  for( NSUInteger maskIndex = 0, digitIndex = 0; maskIndex < self.mask.length; ++maskIndex ) {
-    const unichar maskCharacter = [self.mask characterAtIndex:maskIndex];
-    if( maskCharacter == self.placeholderCharacter ) {
-      if( digitIndex < onlyDigitsString.length ) {
-        [formattedString appendString:[onlyDigitsString substringWithRange:NSMakeRange(digitIndex, 1)]];
-        ++digitIndex;
-      } else {
-        break;
-      }
-    } else if( self.mode != AKNumericFormatterFillIn && [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:maskCharacter] ) {
-      if( digitIndex < onlyDigitsString.length
-        && maskCharacter == [onlyDigitsString characterAtIndex:digitIndex] )
-      {
-        [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
-        ++digitIndex;
-      } else if( self.mode == AKNumericFormatterMixed ) {
-        [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
-      } else {
-        break;
-      }
-    } else {
-      [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
-    }
+
+  NSString *formattedString = @"";
+  switch (self.mode) {
+    case AKNumericFormatterFillIn:
+      formattedString = [self fillInModeFormattedString:onlyDigitsString];
+      break;
+    case AKNumericFormatterMixed:
+      formattedString = [self mixedModeFormattedString:onlyDigitsString];
+      break;
+    case AKNumericFormatterStrict:
+    default:
+      formattedString = [self strictModeFormattedString:onlyDigitsString];
+      break;
   }
+
   if( [formattedString stringContainingOnlyDecimalDigits].length == 0 ) {
     return @"";
   }
@@ -139,6 +129,83 @@
                                 usingMask:self.mask
                      placeholderCharacter:self.placeholderCharacter
                                      mode:AKNumericFormatterFillIn];
+}
+
+//------------------------------------------------------------------------------
+#pragma mark - Private methods
+//------------------------------------------------------------------------------
+
+-(NSString*)strictModeFormattedString:(NSString*)onlyDigitsString
+{
+  NSMutableString* formattedString = [NSMutableString string];
+  for( NSUInteger maskIndex = 0, digitIndex = 0; maskIndex < self.mask.length; ++maskIndex ) {
+    const unichar maskCharacter = [self.mask characterAtIndex:maskIndex];
+    if( maskCharacter == self.placeholderCharacter ) {
+      if( digitIndex < onlyDigitsString.length ) {
+        [formattedString appendString:[onlyDigitsString substringWithRange:NSMakeRange(digitIndex, 1)]];
+        ++digitIndex;
+      } else {
+        break;
+      }
+    } else if( [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:maskCharacter] ) {
+      if( digitIndex < onlyDigitsString.length && maskCharacter == [onlyDigitsString characterAtIndex:digitIndex] ) {
+        [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
+        ++digitIndex;
+      } else {
+        break;
+      }
+    } else if (digitIndex < onlyDigitsString.length) {
+      [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
+    }
+  }
+  return formattedString;
+}
+
+-(NSString*)fillInModeFormattedString:(NSString*)onlyDigitsString
+{
+  NSMutableString* formattedString = [NSMutableString string];
+  for( NSUInteger maskIndex = 0, digitIndex = 0; maskIndex < self.mask.length; ++maskIndex ) {
+    const unichar maskCharacter = [self.mask characterAtIndex:maskIndex];
+    if( maskCharacter == self.placeholderCharacter ) {
+      if( digitIndex < onlyDigitsString.length ) {
+        [formattedString appendString:[onlyDigitsString substringWithRange:NSMakeRange(digitIndex, 1)]];
+        ++digitIndex;
+      } else {
+        break;
+      }
+    } else if (digitIndex < onlyDigitsString.length) {
+      [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
+    }
+  }
+  return formattedString;
+}
+
+-(NSString*)mixedModeFormattedString:(NSString*)onlyDigitsString
+{
+  NSMutableString* formattedString = [NSMutableString string];
+  for( NSUInteger maskIndex = 0, digitIndex = 0; maskIndex < self.mask.length; ++maskIndex ) {
+    const unichar maskCharacter = [self.mask characterAtIndex:maskIndex];
+    if( maskCharacter == self.placeholderCharacter ) {
+      if( digitIndex < onlyDigitsString.length ) {
+        [formattedString appendString:[onlyDigitsString substringWithRange:NSMakeRange(digitIndex, 1)]];
+        ++digitIndex;
+      } else {
+        break;
+      }
+    } else if( [[NSCharacterSet decimalDigitCharacterSet] characterIsMember:maskCharacter] ) {
+      if( digitIndex < onlyDigitsString.length && maskCharacter == [onlyDigitsString characterAtIndex:digitIndex] ) {
+        [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
+        ++digitIndex;
+      } else if( digitIndex < onlyDigitsString.length && maskCharacter != [onlyDigitsString characterAtIndex:digitIndex] ) {
+        [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
+      } else {
+        break;
+      }
+    } else if (digitIndex < onlyDigitsString.length) {
+      [formattedString appendString:[NSString stringWithCharacters:&maskCharacter length:1]];
+    }
+  }
+  return formattedString;
 }
 
 @end

--- a/AKNumericFormatter/AKNumericFormatterTests/AKNumericFormatterTests.m
+++ b/AKNumericFormatter/AKNumericFormatterTests/AKNumericFormatterTests.m
@@ -27,9 +27,9 @@
 {
   AKNumericFormatter* formatter = [AKNumericFormatter formatterWithMask:@"**:**:**" placeholderCharacter:'*'];
   XCTAssertEqualObjects([formatter formatString:@"1"], @"1");
-  XCTAssertEqualObjects([formatter formatString:@"12"], @"12:");
+  XCTAssertEqualObjects([formatter formatString:@"12"], @"12");
   XCTAssertEqualObjects([formatter formatString:@"123"], @"12:3");
-  XCTAssertEqualObjects([formatter formatString:@"1*2*x3*4"], @"12:34:");
+  XCTAssertEqualObjects([formatter formatString:@"1*2*x3*4"], @"12:34");
   XCTAssertEqualObjects([formatter formatString:@"x*12345x*"], @"12:34:5");
   XCTAssertEqualObjects([formatter formatString:@"1234567"], @"12:34:56");
 }
@@ -41,9 +41,9 @@
     AKNumericFormatter* formatter = [AKNumericFormatter formatterWithMask:@"+1(xxx)xx-77-xx" placeholderCharacter:'x' mode:AKNumericFormatterFillIn];
     XCTAssertEqualObjects([formatter formatString:@"1"], @"+1(1");
     XCTAssertEqualObjects([formatter formatString:@"2"], @"+1(2");
-    XCTAssertEqualObjects([formatter formatString:@"123"], @"+1(123)");
+    XCTAssertEqualObjects([formatter formatString:@"123"], @"+1(123");
     XCTAssertEqualObjects([formatter formatString:@"1*2*x3*4"], @"+1(123)4");
-    XCTAssertEqualObjects([formatter formatString:@"x*12345x*"], @"+1(123)45-77-");
+    XCTAssertEqualObjects([formatter formatString:@"x*12345x*"], @"+1(123)45");
     XCTAssertEqualObjects([formatter formatString:@"1234567"], @"+1(123)45-77-67");
     XCTAssertEqualObjects([formatter formatString:@"12345678"], @"+1(123)45-77-67");
   }
@@ -51,26 +51,26 @@
     // AKNumericFormatterStrict mode
     AKNumericFormatter* formatter = [AKNumericFormatter formatterWithMask:@"+1(xxx)xx-77-xx" placeholderCharacter:'x'
                                                                      mode:AKNumericFormatterStrict];
-    XCTAssertEqualObjects([formatter formatString:@"1"], @"+1(");
+    XCTAssertEqualObjects([formatter formatString:@"1"], @"+1");
     XCTAssertEqualObjects([formatter formatString:@"2"], @"");
     XCTAssertEqualObjects([formatter formatString:@"123"], @"+1(23");
-    XCTAssertEqualObjects([formatter formatString:@"1234"], @"+1(234)");
-    XCTAssertEqualObjects([formatter formatString:@"123456"], @"+1(234)56-");
+    XCTAssertEqualObjects([formatter formatString:@"1234"], @"+1(234");
+    XCTAssertEqualObjects([formatter formatString:@"123456"], @"+1(234)56");
     XCTAssertEqualObjects([formatter formatString:@"1234567"], @"+1(234)56-7");
-    XCTAssertEqualObjects([formatter formatString:@"12345677"], @"+1(234)56-77-");
+    XCTAssertEqualObjects([formatter formatString:@"12345677"], @"+1(234)56-77");
     XCTAssertEqualObjects([formatter formatString:@"12345678"], @"+1(234)56-7");
     XCTAssertEqualObjects([formatter formatString:@"123456778"], @"+1(234)56-77-8");
   }
   {
     // AKNumericFormatterMixed mode
     AKNumericFormatter* formatter = [AKNumericFormatter formatterWithMask:@"+1(xxx)xx-77-xx" placeholderCharacter:'x' mode:AKNumericFormatterMixed];
-    XCTAssertEqualObjects([formatter formatString:@"1"], @"+1(");
+    XCTAssertEqualObjects([formatter formatString:@"1"], @"+1");
     XCTAssertEqualObjects([formatter formatString:@"2"], @"+1(2");
     XCTAssertEqualObjects([formatter formatString:@"23"], @"+1(23");
     XCTAssertEqualObjects([formatter formatString:@"123"], @"+1(23");
-    XCTAssertEqualObjects([formatter formatString:@"123456"], @"+1(234)56-77-");
-    XCTAssertEqualObjects([formatter formatString:@"1234567"], @"+1(234)56-77-");
-    XCTAssertEqualObjects([formatter formatString:@"12345677"], @"+1(234)56-77-");
+    XCTAssertEqualObjects([formatter formatString:@"123456"], @"+1(234)56");
+    XCTAssertEqualObjects([formatter formatString:@"1234567"], @"+1(234)56-7");
+    XCTAssertEqualObjects([formatter formatString:@"12345677"], @"+1(234)56-77");
     XCTAssertEqualObjects([formatter formatString:@"12345678"], @"+1(234)56-77-8");
     XCTAssertEqualObjects([formatter formatString:@"123456778"], @"+1(234)56-77-8");
   }


### PR DESCRIPTION
Fix complex mask backspace issue, due to a method swizzling issue in iOS 8.

Ref : https://github.com/blackm00n/AKNumericFormatter/issues/3

Before : 
![aknumericformatter-fail](https://cloud.githubusercontent.com/assets/919691/5493213/a170499a-86b6-11e4-9c85-b622bc462f81.gif)

After : 
![aknumericformatter](https://cloud.githubusercontent.com/assets/919691/5493217/a6fb5fda-86b6-11e4-8e6c-69d7e6ac4169.gif)

Tests were run and succeeded.
